### PR TITLE
Fixed dockerfile by using multi-stage build

### DIFF
--- a/workflow/Dockerfile
+++ b/workflow/Dockerfile
@@ -1,3 +1,11 @@
+FROM maven:3.8.4-openjdk-11-slim AS build
+
+COPY pom.xml .
+
+COPY src ./src
+RUN mvn clean package
+
 FROM openjdk:24-ea-21-jdk-slim-bullseye
-COPY target/*.jar app.jar
+
+COPY --from=build target/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
The first build uses maven to create the target files, and then this is copied over to the jdk build for running the service.