### PR TITLE
fixed security vulnerabilities with image choices for workflow

### DIFF
--- a/workflow/Dockerfile
+++ b/workflow/Dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.8.4-openjdk-11-slim AS build
+FROM maven:3.9 as build
 
 COPY pom.xml .
 
 COPY src ./src
 RUN mvn clean package
 
-FROM openjdk:24-ea-21-jdk-slim-bullseye
+FROM openjdk:25-bookworm
 
 COPY --from=build target/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Using a more updated maven image for the first part of the Dockerfile and a more updated openjdk image for the second part.