### PR TITLE
fix duplicate pipeline execution 

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -1,6 +1,11 @@
 trigger:
   branches:
     include:
+      - master
+
+pr:
+  branches:
+    include:
       - "*"
 
 pool:


### PR DESCRIPTION
Previously it would run the test both on push to non-master branch and upon pull request to merge that branch with master, now it only runs it on pull request (and then upon merge/push to master as before).