### PR TITLE
Added extra job to pipeline 

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -120,3 +120,58 @@ jobs:
         dockerfile: ./order-service/Dockerfile
         tags: $(Build.BuildId),latest
       displayName: Build & Push Order Service Docker Image
+
+  - job: Deploy_to_AKS
+    displayName: Deploy to AKS
+    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
+    dependsOn: Build_And_Deploy
+
+    steps:
+    - task: UseKubectl@1
+      inputs:
+        kubectlVersion: latest
+
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: folex-service-connection
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          az aks get-credentials --resource-group $(ARM_RESOURCE_GROUP) --name $(CLUSTER_NAME)
+        displayName: Get AKS Credentials
+
+    - script: |
+        latest_tag=$(az acr repository show-manifests \
+        --name $(CONTAINER_REGISTRY) \
+        --repository $(ORDER_SERVICE_IMAGE_REPO) \
+        --query "[?tags[?@=='latest']].tags | [0]" \
+        --output tsv)
+        kubectl set image deployment/order-service order-service=$(CONTAINER_REGISTRY).azurecr.io/$(ORDER_SERVICE_IMAGE_REPO):"$latest_tag" --namespace=folex-dev
+      displayName: Update order-service Deployment
+
+    - script: |
+        latest_tag=$(az acr repository show-manifests \
+        --name $(CONTAINER_REGISTRY) \
+        --repository $(FACTORY_IMAGE_REPO) \
+        --query "[?tags[?@=='latest']].tags | [0]" \
+        --output tsv)
+        kubectl set image deployment/factory factory=$(CONTAINER_REGISTRY).azurecr.io/$(FACTORY_IMAGE_REPO):"$latest_tag" --namespace=folex-dev
+      displayName: Update factory Deployment
+
+    - script: |
+        latest_tag=$(az acr repository show-manifests \
+        --name $(CONTAINER_REGISTRY) \
+        --repository $(WEDDING_WATCHES_IMAGE_REPO) \
+        --query "[?tags[?@=='latest']].tags | [0]" \
+        --output tsv)
+        kubectl set image deployment/wedding-watches wedding-watches=$(CONTAINER_REGISTRY).azurecr.io/$(WEDDING_WATCHES_IMAGE_REPO):"$latest_tag" --namespace=folex-dev
+      displayName: Update wedding-watches Deployment
+
+    - script: |
+        latest_tag=$(az acr repository show-manifests \
+        --name $(CONTAINER_REGISTRY) \
+        --repository $(WORKFLOW_IMAGE_REPO) \
+        --query "[?tags[?@=='latest']].tags | [0]" \
+        --output tsv)
+        kubectl set image deployment/workflow workflow=$(CONTAINER_REGISTRY).azurecr.io/$(WORKFLOW_IMAGE_REPO):"$latest_tag" --namespace=folex-dev
+      displayName: Update workflow Deployment


### PR DESCRIPTION
This sets kubernetes deployment images to one with latest build-id without using 'latest' tag and thus avoiding image caching issues.